### PR TITLE
Makes the Python 3 tests mandatory for travis_CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ install:
     - git submodule update --init --recursive
     - python setup.py install
 
-matrix:
-    allow_failures:
-        - python: 3.3
-        - python: 3.4
-        - python: 3.5
-
 script: python scripts/pysunspec_test.py
 
 notifications:


### PR DESCRIPTION
With the py2 to py3 PR the python 3 tests should always be run. This should be merged after the Py2 to Py3 [PR](https://github.com/sunspec/pysunspec/pull/24).