### PR TITLE
Addresses a bug mentioned in issue 31

### DIFF
--- a/sunspec/core/client.py
+++ b/sunspec/core/client.py
@@ -24,7 +24,7 @@
 import os
 import time
 import sunspec.core.modbus.client as modbus
-import sunspec.core.device as device 
+import sunspec.core.device as device
 import sunspec.core.util as util
 import sunspec.core.suns as suns
 from sunspec.core.util import SunSpecError
@@ -366,7 +366,7 @@ class SunSpecClientBlockBase(object):
         if point:
             point.value = value
 
-    def __getitem__(self, key):
+    def __getitem__(self, name):
         return self._get_property(name)
         # return self.__dict__.get(key, None)
 
@@ -380,7 +380,7 @@ class SunSpecClientBlockBase(object):
             value = getattr(self, name)
             if value is not None:
                 s += '%s:  %s\n' % (name, str(value))
-    
+
         return s
 
 def model_class_get(model_id):
@@ -481,7 +481,7 @@ class SunSpecClientDevice(object):
 
     def __setitem__(self, key, item):
         self.__dict__.set(key, item)
-        
+
     def __str__(self):
 
         s = ''


### PR DESCRIPTION
A variable did not match the input from the function. Closes Issue #31 . I do not know if the best path forward though would be changing the input or the variable (`key` -> `name` or `name` -> `key`). I figure changing the input should not cause backwards incompatibilities because the it would not be used as a keyword argument.