### PR TITLE
Rework installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Overview
-
+# pySunSpec
 The pySunSpec package provides objects and applications that support
 interaction with SunSpec compliant devices and documents.  It can be run in
-most environments that support Python and is tested on Wndows 7, MAC OS X, and
+most environments that support Python and is tested on Windows 7, Mac OS X, and
 Ubuntu.
 
 Copyright (c) 2017 SunSpec Alliance
 ([License](https://github.com/sunspec/pysunspec/blob/master/LICENSE))
+
+[![Build Status](https://travis-ci.org/sunspec/pysunspec.svg?branch=master)](https://travis-ci.org/sunspec/pysunspec)
 
 
 # Features
@@ -14,7 +15,7 @@ Copyright (c) 2017 SunSpec Alliance
 - High level object model allowing easy device scripting
 - Minimal dependencies for core package allowing it to run in more constrained
   Python environments
-- Runs on Windows, Mac, and Linux.
+- Runs on Windows, Mac, and Linux
 
 
 # Requirements
@@ -24,38 +25,23 @@ Copyright (c) 2017 SunSpec Alliance
 
 # Installation
 
-The installation instructions are written to utilize a command line. If using
-Windows you will want to open a command prompt window for the installation
-process. If on a Unix system use terminal and you may need to add `sudo` in
-front of the commands if encountering authorization errors.
-
-Note: The installation guide will be showing the commands as if they were run
-in a Unix environment. On Windows the left most part of the command will look
-different (`C:\>` instead of `$`). Do not type `$` as part of the command.
 
 ## Python
 
-If using Unix Python should already be installed whereas Python is not included
-in the standard Windows installation. To check to see if Python is installed
-type `python` into the command line. If it is installed you should enter a
-Python editor. To exit the editor type `quit()`. If successful you should see
-the following
+Since this is a Python library you will need Python installed both to run your
+code and this library.  While there are efforts to support Python 3 versions
+they are not yet complete so the latest version of Python 2 is recommended.
+The CPython interpreter from [python.org](python.org) is commonly used.
+The #python community support channel on the Freenode IRC network is usually
+quite active and has many knowledgeable and helpful users that can assist with
+general Python issues.
 
-```
-$ python
-Python 2.7.1 (r271:86832, Jul 31 2011, 19:30:53) 
-[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)] on darwin
-Type "help", "copyright", "credits" or "license" for more information.
->>>quit()
-```
+Recent versions of the CPython Windows installer offer the option of adding
+the Python installation to the system path.  If you are not familiar with this
+it is likely a good option to select.  It allows you to run Python from a
+shell without having to type the full directory path to Python.  If this option
+is not present you can add the paths manually as below.
 
-If Python did not show up you can acquire it from the Python Software
-Foundation's [download page](http://www.python.org/download). Keep in mind this
-repository currently uses Python 2.7 and not any Python 3.X. Accept all the
-default settings during the installation.
-
-> ### If using Windows and just downloaded Python you need to set environment variables
-> 
 > Set the PATH environment variable to include directories that contain Python
 > packages and scripts. The environment variable settings are at: Computer >
 > System properties > Advanced system settings > Environment Variables.
@@ -72,53 +58,52 @@ default settings during the installation.
 > the 'PATHEXT' variable.
 
 
-## pySerial
-
-To install the pySerial package, try using easy_install
-
-```
-$ easy_install -U pyserial
-```
-
-If easy install is not present on the system download the archive (.tar.gz)
-from https://pypi.python.org/pypi/pyserial (Note if on Windows, use the
-Windows installer option (pyserial-x.y-win32.exe) instead and move on to the
-next section).  Unpack the archive, enter the ``pyserial-x.y`` directory and
-run the following 
-
-```
-$ python setup.py install
-```
-
 ## pySunSpec
 
-**Note:** If getting errors your sunspec/models folder may not have loaded
-during installation due to being a separate repository. Please use the
-following steps to ensure that the library is installed correctly.
-
->If wanting the git repository you have to add the --recursive flag to get the
->submodule to clone as well
->
->```
->$ git clone --recursive https://github.com/sunspec/pysunspec.git
->```
-
-Download the pysunspec archive (.zip) from the [pySunSpec Releases
-Page](https://github.com/sunspec/pysunspec/releases).
-
-Unpack the archive, enter the ``pysunspec-x.y`` directory and run
+When installing from source you need to be sure to have the models available as
+well as the pySunSpec source.  The models repository is referenced in the
+`.gitmodules` file which allows for it to be included with an initial clone.
 
 ```
-$ python setup.py install
+git clone --recursive https://github.com/sunspec/pysunspec.git
 ```
+
+If a non-recursive clone was done, the models can be retreived using the
+`git submodules` command from within your pySunSpec repository clone.
+
+```
+git submodule update --init
+```
+
+Python libraries should generally be installed before use.  This reduces issues
+relating to paths and dependency on the value of the current working directory.
+pySunSpec can be installed per the [package installation tutorial](https://packaging.python.org/tutorials/installing-packages/).
+
+
+## Dependencies
+
+Depending on which installation method you follow you may need to separately
+install the pySerial library that pySunSpec depends on.  This is the case if
+you get an error such as `ImportError: No module named 'serial'` when trying
+to use the pySunSpec code.  pySerial is available as a Python package from
+[PyPi](https://pypi.python.org/pypi/pyserial) and as source from
+[GitHub](https://github.com/pyserial/pyserial) as both a Git repository and
+a .zip download.
+
+## Verifying the pySunSpec Installation
 
 You can test the installation by opening a Command Prompt window and running
-the unittest discover command. You should see the results of the test execution
-with no test failures
+the `unittest discover` command. You should see the results of the test execution
+with no test failures.  Depending on how you chose to install Python and
+pySunSpec (adding Python to the path, using a virtualenv, etc) you may need
+to adjust the `python` portion of the command.
 
+Command:
 ```
-$ python -m unittest discover -v sunspec
-
+python -m unittest discover -v sunspec
+```
+Expected result:
+```
 test_client_device (core.test.test_client.TestClientDevice) ... ok
 test_sunspec_client_device_1 (core.test.test_client.TestClientDevice) ... ok
 test_sunspec_client_device_3 (core.test.test_client.TestClientDevice) ... ok
@@ -146,8 +131,6 @@ test_modbus_mbmap_from_xml_file (core.test.test_modbus_mbmap.TestModbusMap) ... 
 Ran 22 tests in 0.634s
 
 OK
-
-$
 ```
 
 You should now be ready to use the pySunSpec package.
@@ -163,4 +146,4 @@ Docs](https://pysunspec.readthedocs.io/en/latest/) site.
 
 If you have a question, think you've found a bug or have a feature request
 please open an [issue](https://github.com/sunspec/pysunspec/issues) on the
-Github Project Page
+Github Project Page.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pySunSpec
+
 The pySunSpec package provides objects and applications that support
 interaction with SunSpec compliant devices and documents.  It can be run in
 most environments that support Python and is tested on Windows 7, Mac OS X, and
@@ -11,6 +12,7 @@ Copyright (c) 2018 SunSpec Alliance
 
 
 # Features
+
 - Provides access to SunSpec Modbus RTU and TCP devices
 - High level object model allowing easy device scripting
 - Minimal dependencies for core package allowing it to run in more constrained
@@ -19,6 +21,7 @@ Copyright (c) 2018 SunSpec Alliance
 
 
 # Requirements
+
 - Python 2.7, 3.3-3.6
 - pySerial
 
@@ -29,10 +32,10 @@ Copyright (c) 2018 SunSpec Alliance
 ## Python
 
 Since this is a Python library you will need Python installed both to run your
-code and this library.  While there are efforts to support Python 3 versions
-they are not yet complete so the latest version of Python 2 is recommended.
+code and this library.  Supported Python versions are noted above.  Unless
+there is a strong reason not to, it is recommended to use the current Python 3.
 The CPython interpreter from [python.org](python.org) is commonly used.
-The #python community support channel on the Freenode IRC network is usually
+The `#python` community support channel on the Freenode IRC network is usually
 quite active and has many knowledgeable and helpful users that can assist with
 general Python issues.
 
@@ -77,7 +80,11 @@ git submodule update --init
 
 Python libraries should generally be installed before use.  This reduces issues
 relating to paths and dependency on the value of the current working directory.
-pySunSpec can be installed per the [package installation tutorial](https://packaging.python.org/tutorials/installing-packages/).
+It is strongly recommended that you work in an isolated environment such as
+can be created by `venv` or `virtualenv` (see [bit.ly/py-env](bit.ly/py-env)).
+pySunSpec can be installed per the
+[package installation tutorial](https://packaging.python.org/tutorials/installing-packages/)
+which also discusses virtual environments.
 
 
 ## Dependencies
@@ -89,6 +96,7 @@ to use the pySunSpec code.  pySerial is available as a Python package from
 [PyPi](https://pypi.python.org/pypi/pyserial) and as source from
 [GitHub](https://github.com/pyserial/pyserial) as both a Git repository and
 a .zip download.
+
 
 ## Verifying the pySunSpec Installation
 


### PR DESCRIPTION
pySunSpec is a standard Python package so the generic installation instructions are
sufficient and avoid us attempting to describe the various options such as pip vs.
easy_install, use of sudo or not, virtualenv's, etc.

#42