### PR TITLE
Add pyserial as a dependency in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 install: 
     - python -m pip install --upgrade pip setuptools wheel
     - git submodule update --init --recursive
-    - pip install -e .
+    - pip install .
 
 matrix:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ python:
     - 3.5
 
 install: 
+    - python -m pip install --upgrade pip setuptools wheel
     - git submodule update --init --recursive
-    - python setup.py install
+    - pip install -e .
 
 matrix:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
     - 3.5
 
 install: 
-    - python -m pip install --upgrade pip setuptools wheel
     - git submodule update --init --recursive
     - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
     - 3.5
 
 install: 
-    - pip install pyserial
     - git submodule update --init --recursive
     - python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(name = 'pysunspec',
       author_email = ['bob.fox@loggerware.com'],
       packages = ['sunspec', 'sunspec.core', 'sunspec.core.modbus', 'sunspec.core.test', 'sunspec.core.test.fake'],
       package_data = {'sunspec': ['models/smdx/*'], 'sunspec.core.test': ['devices/*']},
-      scripts = ['scripts/suns.py']
+      scripts = ['scripts/suns.py'],
+      install_requires = ['pyserial'],
       )


### PR DESCRIPTION
This could be made an optional dependency but I don't think the extra complexity adds much benefit.