### PR TITLE
Add appveyor.yml for Windows testing/wheel/sdist

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+environment:
+  global:
+    PYTHON: "C:\\Python27"
+
+# https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+init:
+  - ps: if (Get-ChildItem Env:ENABLE_RDP -ErrorAction SilentlyContinue) {iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))} else {echo RDP not enabled}
+
+build_script:
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+  - python -m pip install --upgrade pip setuptools wheel
+  - python -m pip install --user virtualenv
+  - python -m virtualenv -p %PYTHON%\\python.exe venv
+  - git submodule update --init
+  - venv\\scripts\\python -m pip install -e .
+  - venv\\scripts\\python -m unittest discover -v sunspec
+  - venv\\scripts\\python -m pip wheel --wheel-dir dist --no-deps .
+  - venv\\scripts\\python setup.py sdist
+
+artifacts:
+  - path: 'dist/*'
+
+# https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+on_finish:
+  - ps: if (Get-ChildItem Env:ENABLE_RDP -ErrorAction SilentlyContinue) {$blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))} else {echo RDP not enabled}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,15 @@
 environment:
-  global:
-    PYTHON: "C:\\Python27"
+  matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python37-x64"
 
 # https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
 init:


### PR DESCRIPTION
For this to get used:

* Create an AppVeyor account and add this GitHub repository to it
* Settings I choose to change
  * General
    * Build version format
      * {build}
      * Note that with vcversioner or similar this can be overwritten to include the calculated version
  * Environment
    * Environment variables
      * `APPVEYOR_RDP_PASSWORD`
        * Whatever password you might want.  You can click the lock icon to the right to mask the value.  This would only be accessible to people you give permission to to change settings.
      * `ENABLE_RDP`
        * With my code leaving it empty disables it, setting to `1` enables

The [RDP](https://en.wikipedia.org/wiki/Remote_Desktop_Protocol) feature allows you to connect in with a full Windows desktop during the build and check files and try building stuff.  This eases debugging of build issues.  Hopefully this wouldn't need to get used much.

The rest of the configuration is here in the `appveyor.yml` file.

#41