### PR TITLE
[WIP] Add 485 deadtime enforcement

### DIFF
--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -61,6 +61,16 @@ class ModbusClientTimeout(ModbusClientError):
 class ModbusClientException(ModbusClientError):
     pass
 
+
+def wait_until(target, clock):
+    while True:
+        remaining = target - clock()
+         if remaining > 0:
+            time.sleep(remaining)
+        else:
+            break
+
+
 def modbus_rtu_client(name=None, baudrate=None, parity=None):
 
     global modbus_rtu_clients
@@ -242,11 +252,10 @@ class ModbusClientRTU(object):
                 s += '%02X' % (ord(c))
             trace_func(s)
 
-        now = deadtime_clock()
-        delta = now - self.last_receive_completion
-        remaining = self.deadtime - delta
-        if remaining > 0:
-            time.sleep(remaining)
+        wait_until(
+            target=self.last_receive_completion + self.deadtime,
+            clock=deadtime_clock,
+        )
 
         self.serial.flushInput()
         try:
@@ -370,11 +379,10 @@ class ModbusClientRTU(object):
                 s += '%02X' % (ord(c))
             trace_func(s)
 
-        now = deadtime_clock()
-        delta = now - self.last_receive_completion
-        remaining = self.deadtime - delta
-        if remaining > 0:
-            time.sleep(remaining)
+        wait_until(
+            target=self.last_receive_completion + self.deadtime,
+            clock=deadtime_clock,
+        )
 
         self.serial.flushInput()
         try:

--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -65,7 +65,7 @@ class ModbusClientException(ModbusClientError):
 def wait_until(target, clock):
     while True:
         remaining = target - clock()
-         if remaining > 0:
+        if remaining > 0:
             time.sleep(remaining)
         else:
             break

--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -35,6 +35,10 @@ except:
 
 import sunspec.core.modbus.mbmap as mbmap
 
+
+deadtime_clock = getattr(time, 'monotonic', time.clock)
+
+
 PARITY_NONE = 'N'
 PARITY_EVEN = 'E'
 
@@ -238,7 +242,7 @@ class ModbusClientRTU(object):
                 s += '%02X' % (ord(c))
             trace_func(s)
 
-        now = time.monotonic()
+        now = deadtime_clock()
         delta = now - self.last_receive_completion
         remaining = self.deadtime - delta
         if remaining > 0:
@@ -272,7 +276,7 @@ class ModbusClientRTU(object):
                 else:
                     raise ModbusClientTimeout('Response timeout')
         finally:
-            self.last_receive_completion = time.monotonic()
+            self.last_receive_completion = deadtime_clock()
 
         if trace_func:
             s = '%s:%s[addr=%s] <--' % (self.name, str(slave_id), addr)
@@ -366,7 +370,7 @@ class ModbusClientRTU(object):
                 s += '%02X' % (ord(c))
             trace_func(s)
 
-        now = time.monotonic()
+        now = deadtime_clock()
         delta = now - self.last_receive_completion
         remaining = self.deadtime - delta
         if remaining > 0:
@@ -401,7 +405,7 @@ class ModbusClientRTU(object):
                 else:
                     raise ModbusClientTimeout('Response timeout')
         finally:
-            self.last_receive_completion = time.monotonic()
+            self.last_receive_completion = deadtime_clock()
 
         if trace_func:
             s = '%s:%s[addr=%s] <--' % (self.name, str(slave_id), addr)


### PR DESCRIPTION
http://www.modbus.org/docs/Modbus_over_serial_line_V1_02.pdf

2.5.1.1 MODBUS Message RTU Framing

In RTU mode, message frames are separated by a silent interval of at least 3.5 character times.

WIP for:
* [ ] Actually test against master once master works with py3 (such as #60/#62)