### PR TITLE
[WIP] Read bytes in both py2 and py3

### DIFF
--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -232,7 +232,7 @@ class ModbusClientRTU(object):
         if trace_func:
             s = '%s:%s[addr=%s] ->' % (self.name, str(slave_id), addr)
             for c in req:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             trace_func(s)
 
         self.serial.flushInput()
@@ -260,7 +260,7 @@ class ModbusClientRTU(object):
         if trace_func:
             s = '%s:%s[addr=%s] <--' % (self.name, str(slave_id), addr)
             for c in resp:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             trace_func(s)
 
         crc = (resp[-2] << 8) | resp[-1]
@@ -339,7 +339,7 @@ class ModbusClientRTU(object):
         if trace_func:
             s = '%s:%s[addr=%s] ->' % (self.name, str(slave_id), addr)
             for c in req:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             trace_func(s)
 
         self.serial.flushInput()
@@ -359,14 +359,14 @@ class ModbusClientRTU(object):
                         len_remaining = 8 - len(resp)
                         len_found = True
                     else:
-                        except_code = ord(resp[2])
+                        except_code = resp[2]
             else:
                 raise ModbusClientTimeout('Response timeout')
 
         if trace_func:
             s = '%s:%s[addr=%s] <--' % (self.name, str(slave_id), addr)
             for c in resp:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             trace_func(s)
 
 
@@ -675,7 +675,7 @@ class ModbusClientDeviceTCP(object):
         if self.trace_func:
             s = '%s:%s:%s[addr=%s] ->' % (self.ipaddr, str(self.ipport), str(self.slave_id), addr)
             for c in req:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             self.trace_func(s)
 
         try:
@@ -705,7 +705,7 @@ class ModbusClientDeviceTCP(object):
         if self.trace_func:
             s = '%s:%s:%s[addr=%s] <--' % (self.ipaddr, str(self.ipport), str(self.slave_id), addr)
             for c in resp:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             self.trace_func(s)
 
         if except_code:
@@ -781,7 +781,7 @@ class ModbusClientDeviceTCP(object):
         if self.trace_func:
             s = '%s:%s:%s[addr=%s] ->' % (self.ipaddr, str(self.ipport), str(self.slave_id), addr)
             for c in req:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             self.trace_func(s)
 
         try:
@@ -811,7 +811,7 @@ class ModbusClientDeviceTCP(object):
         if self.trace_func:
             s = '%s:%s:%s[addr=%s] <--' % (self.ipaddr, str(self.ipport), str(self.slave_id), addr)
             for c in resp:
-                s += '%02X' % (ord(c))
+                s += '%02X' % (c)
             self.trace_func(s)
 
         if except_code:

--- a/sunspec/core/test/test_modbus_client.py
+++ b/sunspec/core/test/test_modbus_client.py
@@ -46,8 +46,9 @@ class TestModbusClient(unittest.TestCase):
         if d.client.serial.out_buf != b'\x01\x03\x9C\x40\x00\x02\xEB\x8F':
             raise Exception("Modbus request mismatch")
 
-        if data != 'SunS':
-            raise Exception("Read data mismatch - expected: 'SunS' received: %s") % (data)
+        expected = b'SunS'
+        if data != expected:
+            raise Exception("Read data mismatch - expected: {expected} received: {data}".format(expected=repr(expected), data=repr(data)))
 
         d.close()
 
@@ -63,7 +64,7 @@ class TestModbusClient(unittest.TestCase):
         d.client.serial.in_buf = b'\x01\x10\x9C\x40\x00\x02\x6E\x4C'
         d.client.serial.out_buf = b''
 
-        d.write(40000, 'ABCD')
+        d.write(40000, b'ABCD')
 
         if d.client.serial.out_buf != b'\x01\x10\x9C\x40\x00\x02\x04\x41\x42\x43\x44\x8B\xB2':
             raise Exception("Modbus request mismatch")

--- a/sunspec/core/test/test_util.py
+++ b/sunspec/core/test/test_util.py
@@ -74,7 +74,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(util.data_to_double(b'\xc0\x8f\x40\x00\x00\x00\x00\x00'), float(-1000))
 
     def test_data_to_str(self):
-        self.assertEqual(util.data_to_str(b'\x53\x75\x6e\x53\x70\x65\x63\x20\x54\x65\x73\x74\x00'), 'SunSpec Test')
+        self.assertEqual(util.data_to_str(b'\x53\x75\x6e\x53\x70\x65\x63\x20\x54\x65\x73\x74\x00'), b'SunSpec Test')
 
 
     def test_s16_to_data(self):

--- a/sunspec/core/util.py
+++ b/sunspec/core/util.py
@@ -96,14 +96,10 @@ def data_to_double(data):
         return d[0]
 
 def data_to_str(data):
+    data = data.rstrip(b'\0')
+    if len(data) == 0:
+        data = b'\0'
 
-    # Change the data from bytes string to regular string for python 3
-    # compatibility
-    if sys.version_info > (3,):
-        data = str(data, 'latin-1')
-
-    if len(data) > 1:
-        data = data[0] + data[1:].rstrip('\0')
     return data
 
 def s16_to_data(s16, len=None):


### PR DESCRIPTION
First pass at fixing #60.  `data_to_str()` needs a bit more consideration.  Do we want it to output native strings?  Unicode?  Either way someone needs to decide what encoding to use.  Either the SunSpec standard or the person that knows the encoding used for the bytes (I don't think the library has any way to know this at present).

WIP for:
* [ ] `data_to_str()` resolution