### PR TITLE
Close files in PathList.read() to avoid resource warnings

### DIFF
--- a/sunspec/core/util.py
+++ b/sunspec/core/util.py
@@ -242,8 +242,8 @@ class PathList(object):
                 return zip_file.read(file_path)
             else:
                 if os.path.exists(file_path):
-                    f = open(file_path, 'rb')
-                    return f.read()
+                    with open(file_path, 'rb') as f:
+                        return f.read()
                 else:
                     continue
 


### PR DESCRIPTION
```python
/home/altendky/pysunspec/sunspec/core/modbus/mbmap.py:172: ResourceWarning: unclosed file <_io.BufferedReader name='/home/altendky/pysunspec/sunspec/core/test/devices/mbmap_test_device_1.xml'>
  map_data = pathlist.read(filename)
/home/altendky/pysunspec/sunspec/core/device.py:118: ResourceWarning: unclosed file <_io.BufferedReader name='/home/altendky/pysunspec/sunspec/core/test/devices/pics_test_device_1.xml'>
  pics_data = pathlist.read(filename)
/home/altendky/pysunspec/sunspec/core/modbus/mbmap.py:172: ResourceWarning: unclosed file <_io.BufferedReader name='/home/altendky/pysunspec/sunspec/core/test/devices/mbmap_test_device_3.xml'>
  map_data = pathlist.read(filename)
/home/altendky/pysunspec/sunspec/core/device.py:118: ResourceWarning: unclosed file <_io.BufferedReader name='/home/altendky/pysunspec/sunspec/core/test/devices/pics_test_device_2.xml'>
  pics_data = pathlist.read(filename)
/home/altendky/pysunspec/sunspec/core/modbus/mbmap.py:172: ResourceWarning: unclosed file <_io.BufferedReader name='/home/altendky/pysunspec/sunspec/core/test/devices/mbmap_test_device_1_a.xml'>
  map_data = pathlist.read(filename)
/home/altendky/pysunspec/sunspec/core/modbus/mbmap.py:172: ResourceWarning: unclosed file <_io.BufferedReader name='/home/altendky/pysunspec/sunspec/core/test/devices/mbmap_test_device_1_b.xml'>
  map_data = pathlist.read(filename)
/home/altendky/pysunspec/sunspec/core/modbus/mbmap.py:172: ResourceWarning: unclosed file <_io.BufferedReader name='/home/altendky/pysunspec/sunspec/core/test/devices/mbmap_test_device_1_c.xml'>
  map_data = pathlist.read(filename)
```