### PR TITLE
Use pip to install on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ python:
     - 3.8
 
 install:
-    - pip install pyserial
     - git submodule update --init --recursive
-    - python setup.py install
+    - pip install .
 
 script: python -m unittest discover -v sunspec
 


### PR DESCRIPTION
Pip is the proper tool for installing, not running `setup.py` directly.  Additionally, the `pyserial` dependency is now covered by `setup.py` `install_requires`.  This change was present in #46 but got overwritten in https://github.com/sunspec/pysunspec/commit/2a46a869abab2ef54b1586a1400125d7673d6423.