### PR TITLE
Corrected RTU read and write to handle Python 3 properly.

### DIFF
--- a/scripts/suns.py
+++ b/scripts/suns.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
             print('Unknown -t option: %s' % (options.t))
             sys.exit(1)
 
-    except client.SunSpecClientError, e:
+    except client.SunSpecClientError as e:
         print('Error: %s' % (e))
         sys.exit(1)
 

--- a/sunspec/core/modbus/client.py
+++ b/sunspec/core/modbus/client.py
@@ -326,6 +326,9 @@ class ModbusClientRTU(object):
         else:
             raise ModbusClientError('Client serial port not open: %s' % self.name)
 
+        if sys.version_info > (3,):
+            resp = bytes(resp, 'latin-1')
+
         return resp
 
     def _write(self, slave_id, addr, data, trace_func=None):
@@ -339,7 +342,8 @@ class ModbusClientRTU(object):
 
         req = struct.pack('>BBHHB', int(slave_id), func, int(addr), count, len_data)
         if sys.version_info > (3,):
-            data = bytes(data, "latin-1")
+            if type(data) is not bytes:
+                data = bytes(data, "latin-1")
         req += data
         req += struct.pack('>H', computeCRC(req))
         if sys.version_info > (3,):

--- a/sunspec/core/test/test_modbus_client.py
+++ b/sunspec/core/test/test_modbus_client.py
@@ -46,7 +46,7 @@ class TestModbusClient(unittest.TestCase):
         if d.client.serial.out_buf != b'\x01\x03\x9C\x40\x00\x02\xEB\x8F':
             raise Exception("Modbus request mismatch")
 
-        if data != 'SunS':
+        if data != b'SunS':
             raise Exception("Read data mismatch - expected: 'SunS' received: %s") % (data)
 
         d.close()


### PR DESCRIPTION
The Python 3 support code does not look ideal but this fix is consistent with the TCP implementation. pysunspec is being rewritten to support the updated modeling, so this fix is probably sufficient for this version. Addresses issues #60 and #90.
