### PR TITLE
fix key used for model_types cache lookup

### DIFF
--- a/sunspec/core/device.py
+++ b/sunspec/core/device.py
@@ -892,7 +892,7 @@ def model_type_get(model_id):
     global file_pathlist
     global model_types
 
-    model_type = model_types.get(str(model_id))
+    model_type = model_types.get(model_id)
     if model_type is None:
         smdx_data = ''
         # create model file name


### PR DESCRIPTION
Prior to this fix, the core.device.model_types cache was not being utilized due to a mismatch of the key used to store the cached model_type and the key used to retrieve the cached value. Properly utilizing this cache has a huge impact on disk i/o for applications using this library.